### PR TITLE
fix: simplify docker platform for better compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     entrypoint: [ "anvil", "--host", "0.0.0.0", "--block-time", "0.1", "--silent"]
     # Uncomment this if you want to use a fork
     #entrypoint: [ "anvil", "--chain-id", "1", "--fork-url", "http://your_node:845", "--host", "0.0.0.0", "--block-time", "0.1", "--silent"]
-    platform: linux/amd64/v8
+    platform: linux/amd64
     healthcheck:
       test: ["CMD-SHELL", "cast rpc web3_clientVersion | grep -c anvil > /dev/null "]
       start_interval: 250ms


### PR DESCRIPTION
- replacing with more generic linux/amd64 platform target.
- the more specific variant was causing compatibility issues with other images in some systems